### PR TITLE
Update CI because of deprecation

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -2,7 +2,10 @@
 name: Linting
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   precommit:
@@ -73,7 +76,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,10 @@
 name: Testing
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:
@@ -24,7 +27,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:
@@ -71,7 +74,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 [![License][license-shield]](LICENSE)
 
 [![GitHub Activity][commits-shield]][commits-url]
-[![Forks][forks-shield]][forks-url]
+[![PyPi Downloads][downloads-shield]][downloads-url]
+[![GitHub Last Commit][last-commit-shield]][commits-url]
 [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
-[![GitHub Last Commit][last-commit-shield]][commits-url]
+
+[![Code Quality][code-quality-shield]][code-quality]
+[![Build Status][build-shield]][build-url]
+[![Typing Status][typing-shield]][typing-url]
 
 [![Maintainability][maintainability-shield]][maintainability-url]
 [![Code Coverage][codecov-shield]][codecov-url]
-
-[![Build Status][build-shield]][build-url]
-[![Typing Status][typing-shield]][typing-url]
 
 Asynchronous Python client for the open datasets of Zurich (Switzerland).
 
@@ -164,12 +165,14 @@ SOFTWARE.
 <!-- MARKDOWN LINKS & IMAGES -->
 [build-shield]: https://github.com/klaasnicolaas/python-zurich/actions/workflows/tests.yaml/badge.svg
 [build-url]: https://github.com/klaasnicolaas/python-zurich/actions/workflows/tests.yaml
+[code-quality-shield]: https://github.com/klaasnicolaas/python-zurich/actions/workflows/codeql.yaml/badge.svg
+[code-quality]: https://github.com/klaasnicolaas/python-zurich/actions/workflows/codeql.yaml
 [commits-shield]: https://img.shields.io/github/commit-activity/y/klaasnicolaas/python-zurich.svg
 [commits-url]: https://github.com/klaasnicolaas/python-zurich/commits/main
 [codecov-shield]: https://codecov.io/gh/klaasnicolaas/python-zurich/branch/main/graph/badge.svg?token=CLytQU0E0f
 [codecov-url]: https://codecov.io/gh/klaasnicolaas/python-zurich
-[forks-shield]: https://img.shields.io/github/forks/klaasnicolaas/python-zurich.svg
-[forks-url]: https://github.com/klaasnicolaas/python-zurich/network/members
+[downloads-shield]: https://img.shields.io/pypi/dm/zurich
+[downloads-url]: https://pypistats.org/packages/zurich
 [issues-shield]: https://img.shields.io/github/issues/klaasnicolaas/python-zurich.svg
 [issues-url]: https://github.com/klaasnicolaas/python-zurich/issues
 [license-shield]: https://img.shields.io/github/license/klaasnicolaas/python-zurich.svg


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/